### PR TITLE
Add k8s livenessProbe and readinessProbe sections to pods

### DIFF
--- a/k8s/listener-pod.yml
+++ b/k8s/listener-pod.yml
@@ -31,6 +31,7 @@ spec:
         name: broadcaster-listener
         ports:
         - containerPort: 80
+          name: http
         env:
         - name: AUTH_USER
           valueFrom:
@@ -61,4 +62,12 @@ spec:
             limits:
               cpu: "1"
               memory: "100M"
+        livenessProbe:
+          httpGet:
+            path: /status
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /status
+            port: http
       restartPolicy: Always

--- a/k8s/publisher-pod.yml
+++ b/k8s/publisher-pod.yml
@@ -31,6 +31,7 @@ spec:
           name: broadcaster-publisher
           ports:
           - containerPort: 81
+            name: http
           env:
           - name: REDIS_PASSWORD
             valueFrom:
@@ -51,4 +52,12 @@ spec:
             limits:
               cpu: "1"
               memory: "100M"
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: http
       restartPolicy: Always


### PR DESCRIPTION
This PR adds the [livenessProbe and readinessProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes) sections to pods 